### PR TITLE
PDF Service changes.

### DIFF
--- a/pdf-service/src/index.js
+++ b/pdf-service/src/index.js
@@ -596,13 +596,15 @@ export const fillValues = (variableTovalueMap, formatconfig) => {
   let output = JSON.parse(
     mustache
       .render(input, variableTovalueMap)
-      .replace(/""/g, '"')
+      .replace(/" "/g, '""')
       .replace(/\\/g, "")
       .replace(/"\[/g, "[")
       .replace(/\]"/g, "]")
       .replace(/\]\[/g, "],[")
       .replace(/"\{/g, "{")
       .replace(/\}"/g, "}")
+      .replace(/\n/g, "\\n")
+      .replace(/,]/g, "]")
   );
   return output;
 };

--- a/pdf-service/src/utils/directMapping.js
+++ b/pdf-service/src/utils/directMapping.js
@@ -72,7 +72,8 @@ export const directMapping = async (
       variableTovalueMap[directArr[i].jPath] = fun(directArr[i].val[0]);
     } else if (directArr[i].type == "image") {
       try {
-        var response = await axios.get(directArr[i].url, {
+        const url = directArr[i].url || directArr[i].val[0]
+        var response = await axios.get(url, {
           responseType: "arraybuffer"
         });
         variableTovalueMap[directArr[i].jPath] =


### PR DESCRIPTION
1. Mustache render is parsed into JSON and we are missing out on properly rendering a parsable JSON. Added fixes to make sure we are able to produce valid json for quote, space, new line, array charaters.
2. There is support for displaying static images using config but not when the image is a key in the data. Made sure both static images and JSON path work.